### PR TITLE
Ports the config-side Discord hub link from Bee

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -503,3 +503,7 @@
 /datum/config_entry/string/discord_guildid
 
 /datum/config_entry/string/discord_roleid
+
+/datum/config_entry/string/discordurl
+
+/datum/config_entry/string/websiteurl

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -306,11 +306,11 @@ GLOBAL_VAR(restart_counter)
 		hostedby = CONFIG_GET(string/hostedby)
 
 	s += "<b>[station_name()]</b>";
-	s += " ("
-	s += "<a href=\"http://\">" //Change this to wherever you want the hub to link to.
-	s += "Default"  //Replace this with something else. Or ever better, delete it and uncomment the game version.
-	s += "</a>"
-	s += ")"
+	
+	var/discordurl = CONFIG_GET(string/discordurl)
+	var/websiteurl = CONFIG_GET(string/websiteurl)
+	s += " (<a href='[discordurl]'>Discord</a>|<a href='[websiteurl]'>Website</a>)"
+
 
 	var/players = GLOB.clients.len
 

--- a/config/config.txt
+++ b/config/config.txt
@@ -512,3 +512,9 @@ REQUIRED_LIVING_HOURS 0
 
 ## Add the ID of the role you want assigning here
 #DISCORD_ROLEID 000000000000000000
+
+## Discord URL for the hub
+DISCORDURL https://discord.gg/example
+
+## Website URL for the hub
+WEBSITEURL https://example.com


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Original PR by Zert0x: https://github.com/BeeStation/BeeStation-Hornet/pull/5971

As the title states, this ports the config-side Discord hub link from Bee.

I extended it to include the website link as well, and i added in some example configs.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:Zert0x, ported and modified by sergeirocks100
server: The Discord and website links on the hub are now defined in the config, instead of hardcoded.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
